### PR TITLE
Fix behaviour when using PROXY and HTTP/2

### DIFF
--- a/mod_proxy_protocol.c
+++ b/mod_proxy_protocol.c
@@ -333,6 +333,18 @@ static int pp_hook_pre_connection(conn_rec *c, void *csd)
     pp_config *conf;
     pp_conn_config *conn_conf;
 
+    /* Establish master config in slave connections, so that request
+     * processing finds it. */
+    if (c->master != NULL) {
+        conn_conf = ap_get_module_config(c->master->conn_config,
+                                         &proxy_protocol_module);
+        if (conn_conf) {
+            ap_set_module_config(c->conn_config, &proxy_protocol_module,
+                                 conn_conf);
+        }
+        return DECLINED;
+    }
+
     /* check if we're enabled for this connection */
     conf = ap_get_module_config(ap_server_conf->module_config,
                                 &proxy_protocol_module);


### PR DESCRIPTION
Backported from @icing at mod_remoteip f1d5f5d6b8577b2428082050cb03531d7614dba4 - fixes roadrunner2/mod-proxy-protocol#6