### PR TITLE
Fix an issue when running 'make install'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: .libs/mod_proxy_protocol.so
 
 # install the so - usually needs root access
 install: .libs/mod_proxy_protocol.so
-	$(APXS) -i mod_proxy_protocol.c
+	$(APXS) -i mod_proxy_protocol.la
 
 # generate the html doc
 docs: mod_proxy_protocol.html


### PR DESCRIPTION
mod_proxy_protocol.c was getting installed instead of mod_proxy_protocol.so
OS: Debian GNU/Linux 9.9 (stretch)
HW: Pine A64+
Error encountered:
lrdshaper@Corinthian$~/devel/native/mod-proxy-protocol# sudo make install
apxs -i mod_proxy_protocol.c
/usr/share/apache2/build/instdso.sh SH_LIBTOOL='/usr/share/apr-1.0/build/libtool' mod_proxy_protocol.c /usr/lib/apache2/modules
/usr/share/apr-1.0/build/libtool --mode=install install mod_proxy_protocol.c /usr/lib/apache2/modules/
libtool: install: install mod_proxy_protocol.c /usr/lib/apache2/modules/mod_proxy_protocol.c
Warning!  dlname not found in /usr/lib/apache2/modules/mod_proxy_protocol.c.
Assuming installing a .so rather than a libtool archive.
chmod 644 /usr/lib/apache2/modules/mod_proxy_protocol.so
chmod: cannot access '/usr/lib/apache2/modules/mod_proxy_protocol.so': No such file or directory
apxs:Error: Command failed with rc=65536
.
Makefile:19: recipe for target 'install' failed
make: *** [install] Error 1
