### PR TITLE
CVE-2019-10097 Fix Backport.

### DIFF
--- a/mod_proxy_protocol.c
+++ b/mod_proxy_protocol.c
@@ -550,14 +550,13 @@ static pp_parse_status_t pp_process_v2_header(conn_rec *c,
                     break;
 
                 default:
-                    /* unsupported protocol, keep local connection address */
-                    return HDR_DONE;
+                    /* unsupported protocol */
+                    ap_log_cerror(APLOG_MARK, APLOG_ERR, 0, c, APLOGNO(10183)
+                          "RemoteIPProxyProtocol: unsupported protocol %.2hx",
+                           (unsigned short)hdr->v2.fam);
+                    return HDR_ERROR;
             }
             break;  /* we got a sockaddr now */
-
-        case 0x00: /* LOCAL command */
-            /* keep local connection address for LOCAL */
-            return HDR_DONE;
 
         default:
             /* not a supported command */
@@ -646,12 +645,25 @@ static apr_status_t pp_input_filter(ap_filter_t *f,
     /* try to read a header's worth of data */
     while (!ctx->done) {
         if (APR_BRIGADE_EMPTY(ctx->bb)) {
-            ret = ap_get_brigade(f->next, ctx->bb, ctx->mode, block,
-                                 ctx->need - ctx->rcvd);
+            apr_off_t got, want = ctx->need - ctx->rcvd;
+            ret = ap_get_brigade(f->next, ctx->bb, ctx->mode, block, want);
             if (ret != APR_SUCCESS) {
+                ap_log_cerror(APLOG_MARK, APLOG_ERR, ret, f->c, APLOGNO(10184)
+                       "failed reading input");
                 return ret;
             }
+
+            ret = apr_brigade_length(ctx->bb, 1, &got);
+            if (ret || got > want) {
+              ap_log_cerror(APLOG_MARK, APLOG_ERR, ret, f->c, APLOGNO(10185)
+                     "RemoteIPProxyProtocol header too long, "
+                     "got %" APR_OFF_T_FMT " expected %" APR_OFF_T_FMT,
+                     got, want);
+              f->c->aborted = 1;
+              return APR_ECONNABORTED;
+            }
         }
+
         if (APR_BRIGADE_EMPTY(ctx->bb)) {
             return APR_EOF;
         }
@@ -699,6 +711,13 @@ static apr_status_t pp_input_filter(ap_filter_t *f,
 
                 if (ctx->rcvd >= MIN_V2_HDR_LEN) {
                     ctx->need = MIN_V2_HDR_LEN + ntohs(hdr->v2.len);
+                    if (ctx->need > sizeof(proxy_v2)) {
+                      ap_log_cerror(APLOG_MARK, APLOG_ERR, 0, f->c, APLOGNO(10186)
+                             "RemoteIPProxyProtocol protocol header length too long");
+                      f->c->aborted = 1;
+                      apr_brigade_destroy(ctx->bb);
+                      return APR_ECONNABORTED;
+                    }
                 }
                 if (ctx->rcvd >= ctx->need) {
                     psts = pp_process_v2_header(f->c, conn_conf, hdr);


### PR DESCRIPTION
This is a backport of the fixes to Apache HTTPD `mod_remoteip` PROXY support for [CVE-2019-10097](https://www.openwall.com/lists/oss-security/2019/08/15/5) that Joe Orton and myself [prepared for HTTPD 2.4.41](http://svn.apache.org/viewvc?view=revision&revision=1864526)

> When mod_remoteip was configured to use a trusted intermediary proxy server using the "PROXY" protocol, a specially crafted PROXY header could trigger a stack buffer overflow or NULL pointer deference. This vulnerability could only be triggered by a trusted proxy and not by untrusted HTTP clients.

The Apache security team gave this a "Moderate" severity rating.

The PROXY support in `mod_remoteip` is descendent from `mod-proxy-protocol`, necessitating the backport of this fix. Based on code review I believe the same stack overflow and null pointer deref affect this project's original implementation but unlike with `mod_remoteip` I haven't set up a live server to verify this empirically. [My original report](https://gist.github.com/cpu/bf9520b05b3077986ed87f4a40902660) to the Apache security team has more detail on the nature of the bugs and reproduction steps that should aid the project maintainers when evaluating this patch.